### PR TITLE
Fix IndexPath construction

### DIFF
--- a/calendarCollectionViewLayout/CalendarDataSource.swift
+++ b/calendarCollectionViewLayout/CalendarDataSource.swift
@@ -39,8 +39,8 @@ class CalendarDataSource: NSObject, UICollectionViewDataSource {
 
         for (idx, event) in self.events!.enumerated() {
             if event.day >= minDayIndex && event.day <= maxDayIndex && event.startHour >= minStartHour && event.startHour <= maxStartHour {
-                let indexPath: IndexPath? = IndexPath.init(arrayLiteral: idx)
-                indexPaths?.append(indexPath!)
+                let indexPath = IndexPath(indexes: [0,idx])
+                indexPaths?.append(indexPath)
             }
         }
         print("\(indexPaths)")

--- a/calendarCollectionViewLayout/WeekCalendarLayout.swift
+++ b/calendarCollectionViewLayout/WeekCalendarLayout.swift
@@ -119,7 +119,7 @@ class WeekCalendarLayout: UICollectionViewLayout {
         var indexPaths: [IndexPath]? = []
         let idx = minDayIndex
         for idx in idx..<maxDayIndex {
-            let indexPath = IndexPath.init(index: idx)
+            let indexPath = IndexPath(indexes: [0,idx])
             indexPaths?.append(indexPath)
         }
 
@@ -137,7 +137,7 @@ class WeekCalendarLayout: UICollectionViewLayout {
         var indexPaths: [IndexPath]? = []
         let idx = minHourIndex
         for idx in idx..<maxHourIndex {
-            let indexPath = IndexPath.init(index: idx)
+            let indexPath = IndexPath(indexes: [0,idx])
             indexPaths?.append(indexPath)
         }
 


### PR DESCRIPTION
The index paths in my example are all two-dimensional (section and
item), so we must construct them that way (assigning a section of 0 to
all works).

This fixes the crashes.

General observation: you're using way too many optionals when it's not
necessary. I fixed one instance, but they are many more. For example,
it's almost never a good idea to have an optional array of something
(as in `var indexPaths: [IndexPath]? = []`) because an empty array is
practically the same thing as no array at all.